### PR TITLE
added waitForRunLater method

### DIFF
--- a/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationTest.java
+++ b/subprojects/testfx-junit/src/main/java/org/testfx/framework/junit/ApplicationTest.java
@@ -16,12 +16,13 @@
  */
 package org.testfx.framework.junit;
 
+import java.util.concurrent.Semaphore;
 import javafx.application.Application;
 import javafx.application.Application.Parameters;
 import javafx.application.HostServices;
+import javafx.application.Platform;
 import javafx.application.Preloader.PreloaderNotification;
 import javafx.stage.Stage;
-
 import org.junit.After;
 import org.junit.Before;
 import org.testfx.api.FxRobot;
@@ -76,6 +77,12 @@ public abstract class ApplicationTest extends FxRobot implements ApplicationFixt
     @Unstable(reason = "is missing apidocs")
     public void stop()
               throws Exception {}
+
+    public void waitForRunLater() throws InterruptedException {
+        final Semaphore semaphore = new Semaphore(0);
+        Platform.runLater(() -> semaphore.release());
+        semaphore.acquire();
+    }
 
     @Deprecated
     public final HostServices getHostServices() {

--- a/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationRunLaterTest.java
+++ b/subprojects/testfx-junit/src/test/java/org/testfx/cases/acceptance/ApplicationRunLaterTest.java
@@ -1,0 +1,45 @@
+package org.testfx.cases.acceptance;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+import org.junit.Test;
+import org.testfx.api.FxToolkit;
+import org.testfx.framework.junit.ApplicationTest;
+
+import static org.testfx.api.FxAssert.verifyThat;
+import static org.testfx.matcher.base.NodeMatchers.hasText;
+
+public class ApplicationRunLaterTest extends ApplicationTest {
+    @Override
+    public void init() throws Exception {
+        FxToolkit.registerStage(() -> new Stage());
+    }
+
+    @Override
+    public void start(Stage stage) {
+        Button button = new Button("click me!");
+        button.setOnAction((actionEvent) -> Platform.runLater(() -> button.setText("clicked!")));
+        stage.setScene(new Scene(new StackPane(button), 100, 100));
+        stage.show();
+    }
+
+    @Override
+    public void stop() throws Exception {
+        FxToolkit.hideStage();
+    }
+
+    @Test
+    public void should_contain_button() {
+        verifyThat(".button", hasText("click me!"));
+    }
+
+    @Test
+    public void should_click_on_button() throws Exception {
+        clickOn(".button");
+        waitForRunLater();
+        verifyThat(".button", hasText("clicked!"));
+    }
+}


### PR DESCRIPTION
It's useful while testing stuff that is behind a Platform.runLater call,
  so it is not needed to add sleeps to tests.

Source:
http://stackoverflow.com/questions/22821129/wait-for-platform-runlater-in-a-unit-test